### PR TITLE
Update official links

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@zeroopensource/zero-cli": "workspace:^",
     "@zeroopensource/zero-hello": "workspace:^"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.11.1",
   "engines": {
     "node": ">=18"
   }

--- a/packages/zero-cli/package.json
+++ b/packages/zero-cli/package.json
@@ -18,6 +18,11 @@
     "build": "tsup"
   },
   "dependencies": {
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "resolve": "1.22.10",
+    "@zeroopensource/zero-official": "latest"
+  },
+  "devDependencies": {
+    "@types/resolve": "1.20.6"
   }
 }

--- a/packages/zero-cli/pnpm-lock.yaml
+++ b/packages/zero-cli/pnpm-lock.yaml
@@ -8,16 +8,97 @@ importers:
 
   .:
     dependencies:
+      '@zeroopensource/zero-official':
+        specifier: latest
+        version: 0.0.2
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      resolve:
+        specifier: 1.22.10
+        version: 1.22.10
+    devDependencies:
+      '@types/resolve':
+        specifier: 1.20.6
+        version: 1.20.6
 
 packages:
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@zeroopensource/zero-cli@0.0.2':
+    resolution: {integrity: sha512-3cN0MEFT1noX3ne0kpZHjwKLsds6P0gPllrtvNdrbIBAxWf5ZDsV1EA+SqGf9neVQEm/keqMzy92/CS1Vjgh0w==}
+    hasBin: true
+
+  '@zeroopensource/zero-official@0.0.2':
+    resolution: {integrity: sha512-L+sElsDb35vx6o6JHf/onC74gHBZuEj3CO6JOj8buQ8cmo1BLIjX/tZMuMeWIDQX1Bwd+zpEN1KGtdzmFwkm+g==}
+    hasBin: true
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
 snapshots:
 
+  '@types/resolve@1.20.6': {}
+
+  '@zeroopensource/zero-cli@0.0.2':
+    dependencies:
+      commander: 14.0.0
+
+  '@zeroopensource/zero-official@0.0.2':
+    dependencies:
+      '@zeroopensource/zero-cli': 0.0.2
+      commander: 10.0.1
+
+  commander@10.0.1: {}
+
   commander@14.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  path-parse@1.0.7: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}

--- a/packages/zero-cli/pnpm-lock.yaml
+++ b/packages/zero-cli/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@zeroopensource/zero-official':
         specifier: latest
-        version: 0.0.2
+        version: 0.0.3
       commander:
         specifier: ^14.0.0
         version: 14.0.0
@@ -31,8 +31,8 @@ packages:
     resolution: {integrity: sha512-3cN0MEFT1noX3ne0kpZHjwKLsds6P0gPllrtvNdrbIBAxWf5ZDsV1EA+SqGf9neVQEm/keqMzy92/CS1Vjgh0w==}
     hasBin: true
 
-  '@zeroopensource/zero-official@0.0.2':
-    resolution: {integrity: sha512-L+sElsDb35vx6o6JHf/onC74gHBZuEj3CO6JOj8buQ8cmo1BLIjX/tZMuMeWIDQX1Bwd+zpEN1KGtdzmFwkm+g==}
+  '@zeroopensource/zero-official@0.0.3':
+    resolution: {integrity: sha512-3oqWIjtRQWA1CMeWyQLFQnhrhQK5XS7WuWofkzPti4RcVNyxOKpshQmJamAojbaHOMO1ptbt4BR9XUn7Kr0XbA==}
     hasBin: true
 
   commander@10.0.1:
@@ -74,7 +74,7 @@ snapshots:
     dependencies:
       commander: 14.0.0
 
-  '@zeroopensource/zero-official@0.0.2':
+  '@zeroopensource/zero-official@0.0.3':
     dependencies:
       '@zeroopensource/zero-cli': 0.0.2
       commander: 10.0.1

--- a/packages/zero-cli/src/zero-cli.ts
+++ b/packages/zero-cli/src/zero-cli.ts
@@ -1,22 +1,10 @@
 #!/usr/bin/env node
-import { readdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
-import { createRequire } from 'module'
 import {
   program,
   // InvalidArgumentError
 } from 'commander'
 import packagejson from '../package.json'
-
-const require = createRequire(__filename)
-const root = dirname(require.resolve('@zeroopensource/zero-cli/package.json'))
-const nodeModulesRoot = join(
-  root,
-  '..',
-  '..',
-  'node_modules',
-  '@zeroopensource'
-)
+import { ZERO_OFFICIAL_LINKS } from '@zeroopensource/zero-official'
 
 // TODO: Import from official repo
 const officialLinks = {
@@ -42,75 +30,6 @@ program
     }
     console.log()
   })
-
-program
-  .command('list')
-  .description('List installed Zero subcommands')
-  .action(async () => {
-    try {
-      const packages = await readdir(nodeModulesRoot, { withFileTypes: true })
-      const zeroPackages = packages
-        .filter(
-          d =>
-            (d.isDirectory() || d.isSymbolicLink()) &&
-            d.name.startsWith('zero-') &&
-            d.name !== 'zero-cli'
-        )
-        .map(d => ({
-          name: d.name.replace('zero-', ''),
-          full: `@zeroopensource/${d.name}`,
-        }))
-
-      if (zeroPackages.length === 0) {
-        console.log('No other Zero subcommands installed.')
-      } else {
-        console.log('Available Zero subcommands:\n')
-        for (const pkg of zeroPackages) {
-          console.log(`  ${pkg.name.padEnd(12)} ${pkg.full}`)
-        }
-        console.log()
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      console.error('Failed to list installed Zero subcommands:', message)
-      process.exit(1)
-    }
-  })
-
-const builtinCommands = ['official', 'list', '--help', '-h', '--version', '-v']
-const [, , potentialSubcommand, ...restArgs] = process.argv
-
-;(async () => {
-  if (
-    potentialSubcommand &&
-    !builtinCommands.includes(potentialSubcommand) &&
-    !potentialSubcommand.startsWith('-')
-  ) {
-    // Handle dynamic subcommand: zero <subcommand>
-    const moduleName = `@zeroopensource/zero-${potentialSubcommand}/cli`
-    try {
-      const mod = await import(moduleName)
-      const subProgram = mod.default
-
-      if (typeof subProgram?.parseAsync === 'function') {
-        await subProgram.parseAsync(restArgs, { from: 'user' })
-      } else {
-        console.error(
-          `❌ ${moduleName} does not export a Commander Command instance.`
-        )
-        process.exit(1)
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      console.error(`\n❌ Failed to run subcommand "${potentialSubcommand}"`)
-      console.error(`→ Tried to load: ${moduleName}`)
-      console.error(`→ Error: ${message}\n`)
-      process.exit(1)
-    }
-  } else {
-    await program.parseAsync(process.argv)
-  }
-})()
 
 const noSubCommand = process.argv.length <= 2
 if (noSubCommand) {

--- a/packages/zero-cli/src/zero-cli.ts
+++ b/packages/zero-cli/src/zero-cli.ts
@@ -24,6 +24,8 @@ program
     console.log()
   })
 
+program.parse(process.argv)
+
 const noSubCommand = process.argv.length <= 2
 if (noSubCommand) {
   program.help()

--- a/packages/zero-cli/src/zero-cli.ts
+++ b/packages/zero-cli/src/zero-cli.ts
@@ -6,13 +6,6 @@ import {
 import packagejson from '../package.json'
 import { ZERO_OFFICIAL_LINKS } from '@zeroopensource/zero-official'
 
-// TODO: Import from official repo
-const officialLinks = {
-  'All Official Links': 'https://github.com/zeroopensource/zero-official',
-  GitHub: 'https://github.com/zeroopensource',
-  Website: 'https://zeroopensource.org',
-}
-
 program
   .name(Object.keys(packagejson.bin)[0] || 'zero')
   .version(packagejson.version || '0.0.0', '-v, --version')
@@ -25,8 +18,8 @@ program
   .description('Show official links for Zero Open Source')
   .action(() => {
     console.log('\nOfficial Links:\n')
-    for (const [label, url] of Object.entries(officialLinks)) {
-      console.log(`  ${label}: ${url}`)
+    for (const [_key, value] of Object.entries(ZERO_OFFICIAL_LINKS)) {
+      console.log(`  ${value.name}: ${value.url}`)
     }
     console.log()
   })

--- a/packages/zero-hello/src/cli.ts
+++ b/packages/zero-hello/src/cli.ts
@@ -13,8 +13,4 @@ program
 
 export const cli = program
 
-export const cli2 = () => {
-  console.log('Hello from zero-hello CLI subcommand!')
-}
-
 export default cli


### PR DESCRIPTION
- Removed unused cli2 subcommand function from zero-hello CLI module to simplify the codebase.
- Added @zeroopensource/zero-official as a dependency in zero-cli for centralized official links and related functionality.
- Cleaned zero-cli by removing unused imports and deprecated 'list' command.
- Updated pnpm-lock.yaml with new dependencies and bumped pnpm version to 10.11.1.
- Updated @zeroopensource/zero-official dependency to v0.0.3 and refactored zero-cli output to use ZERO_OFFICIAL_LINKS constant.
- Enabled command line argument parsing in zero-cli.ts with program.parse(process.argv).