### PR TITLE
feat(cli): add `id` command to generate random hex IDs

### DIFF
--- a/.changeset/calm-ravens-explode.md
+++ b/.changeset/calm-ravens-explode.md
@@ -1,0 +1,5 @@
+---
+"@zeroopensource/zero-cli": patch
+---
+
+feat(cli): add `id` command to generate random hex IDs

--- a/packages/zero-cli/package.json
+++ b/packages/zero-cli/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "commander": "^14.0.0",
     "resolve": "1.22.10",
-    "@zeroopensource/zero-official": "latest"
+    "@zeroopensource/zero-official": "latest",
+    "@zeroopensource/zero-id": "latest"
   },
   "devDependencies": {
     "@types/resolve": "1.20.6"

--- a/packages/zero-cli/pnpm-lock.yaml
+++ b/packages/zero-cli/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@zeroopensource/zero-id':
+        specifier: latest
+        version: 0.0.2
       '@zeroopensource/zero-official':
         specifier: latest
         version: 0.0.3
@@ -27,8 +30,12 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  '@zeroopensource/zero-cli@0.0.2':
-    resolution: {integrity: sha512-3cN0MEFT1noX3ne0kpZHjwKLsds6P0gPllrtvNdrbIBAxWf5ZDsV1EA+SqGf9neVQEm/keqMzy92/CS1Vjgh0w==}
+  '@zeroopensource/zero-cli@0.0.3':
+    resolution: {integrity: sha512-srn+ZaV+M1zJrQzNTbKB4crCpxTbX0scPgvAjA1fRYqlTklz/lSwMqeZ5LJDYaepgB2Kf5QxbOsHAaNpMBrLKg==}
+    hasBin: true
+
+  '@zeroopensource/zero-id@0.0.2':
+    resolution: {integrity: sha512-jkOK0235dOzMqX7SvK7CpD4c66lK5IkbwY1/HqA826ppI02SLmOi77MHpAxO0KyZndPTKeUCxdWgSLVZXRjpVA==}
     hasBin: true
 
   '@zeroopensource/zero-official@0.0.3':
@@ -70,13 +77,19 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@zeroopensource/zero-cli@0.0.2':
+  '@zeroopensource/zero-cli@0.0.3':
     dependencies:
+      '@zeroopensource/zero-official': 0.0.3
       commander: 14.0.0
+      resolve: 1.22.10
+
+  '@zeroopensource/zero-id@0.0.2':
+    dependencies:
+      commander: 10.0.1
 
   '@zeroopensource/zero-official@0.0.3':
     dependencies:
-      '@zeroopensource/zero-cli': 0.0.2
+      '@zeroopensource/zero-cli': 0.0.3
       commander: 10.0.1
 
   commander@10.0.1: {}

--- a/packages/zero-cli/src/commander-parse-int.ts
+++ b/packages/zero-cli/src/commander-parse-int.ts
@@ -1,0 +1,9 @@
+import { InvalidArgumentError } from 'commander'
+
+export const commanderParseInt = (value: string) => {
+  const parsedValue = parseInt(value, 10)
+  if (isNaN(parsedValue)) {
+    throw new InvalidArgumentError('not a number')
+  }
+  return parsedValue
+}

--- a/packages/zero-cli/src/zero-cli.ts
+++ b/packages/zero-cli/src/zero-cli.ts
@@ -5,6 +5,8 @@ import {
 } from 'commander'
 import packagejson from '../package.json'
 import { ZERO_OFFICIAL_LINKS } from '@zeroopensource/zero-official'
+import { generateZeroId } from '@zeroopensource/zero-id'
+import { commanderParseInt } from './commander-parse-int'
 
 program
   .name(Object.keys(packagejson.bin)[0] || 'zero')
@@ -22,6 +24,26 @@ program
       console.log(`  ${value.name}: ${value.url}`)
     }
     console.log()
+  })
+
+program
+  .command('id')
+  .description('output random hexadecimal id')
+  .option(
+    '--hexLength <value>',
+    'limit length of each hex (default: 6)',
+    commanderParseInt
+  )
+  .option(
+    '--hexNum <value>',
+    'specify number of hexes (default: 6)',
+    commanderParseInt
+  )
+  .option('--prefix <value>', 'add prefix')
+  .option('--suffix <value>', 'add suffix')
+  .option('--divider <value>', `change divider (default: '-')`)
+  .action(options => {
+    console.log(generateZeroId({ prefix: 'zero1', ...options }))
   })
 
 program.parse(process.argv)


### PR DESCRIPTION
- Add `id` subcommand in zero-cli to generate random hexadecimal IDs with customizable hex length, number of segments, prefix, suffix, and divider.
- Implement helper parser for integer options to validate numeric inputs.
- Update dependencies to include the new zero-id package and bump versions accordingly.